### PR TITLE
react to DNX changes in beta7

### DIFF
--- a/src/Glimpse.Common/Reflection/DefaultAssemblyProvider.cs
+++ b/src/Glimpse.Common/Reflection/DefaultAssemblyProvider.cs
@@ -17,7 +17,7 @@ namespace Glimpse
         public IEnumerable<Assembly> GetCandidateAssemblies(string coreLibrary)
         {
             var libraries = _manager.GetReferencingLibraries(coreLibrary);
-            var assemblyNames = libraries.SelectMany(l => l.LoadableAssemblies);
+            var assemblyNames = libraries.SelectMany(l => l.Assemblies);
             var assemblies = assemblyNames.Select(x => Assembly.Load(x));
 
             return assemblies;


### PR DESCRIPTION
Beta7 will introduce some renames to the runtime. This PR updates Glimpse.Prototype to react to those. We're still waiting on a final build that includes these changes to appear on `aspnetvnext`. I'll ping this PR when that happens.
