### PR TITLE
User identification

### DIFF
--- a/src/Glimpse.Agent.Web/Inspectors/UserInspector.cs
+++ b/src/Glimpse.Agent.Web/Inspectors/UserInspector.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+
+namespace Glimpse.Agent.Web.Inspectors
+{
+    public class UserInspector : IInspector
+    {
+        public Task Before(HttpContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task After(HttpContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Glimpse.Agent.Web/Inspectors/UserInspector.cs
+++ b/src/Glimpse.Agent.Web/Inspectors/UserInspector.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using Glimpse.Agent.Web.Framework;
 using Glimpse.Agent.Web.Message;
 using Microsoft.AspNet.Http;
@@ -9,7 +10,9 @@ namespace Glimpse.Agent.Web.Inspectors
     public class UserInspector : Inspector
     {
         private readonly IAgentBroker _broker;
-        private const string GlimpseCookie = ".Glimpse.Session";
+        private const string GlimpseCookie = ".Glimpse.Session"; // TODO: Move this somewhere configurable
+        private readonly ConcurrentDictionary<string, string> _gravatarCache = new ConcurrentDictionary<string, string>(); 
+        private readonly ConcurrentDictionary<string, string> _crcCache = new ConcurrentDictionary<string, string>(); 
 
         public UserInspector(IAgentBroker broker)
         {
@@ -33,9 +36,9 @@ namespace Glimpse.Agent.Web.Inspectors
                 }
             }
 
-            var username = user.FindFirst("name")?.Value ?? userId.Crc16().ToUpper();
+            var username = user.FindFirst("name")?.Value ?? _crcCache.GetOrAdd(userId, id => id.Crc16().ToUpper());
             var email = user.FindFirst("email")?.Value;
-            var pic = user.FindFirst("picture")?.Value ?? GenerateGravatarUrl(email ?? userId);
+            var pic = user.FindFirst("picture")?.Value ?? _gravatarCache.GetOrAdd(email ?? userId, GenerateGravatarUrl);
 
             _broker.SendMessage(new UserIdentification(userId, username, email, pic));
         }

--- a/src/Glimpse.Agent.Web/Inspectors/UserInspector.cs
+++ b/src/Glimpse.Agent.Web/Inspectors/UserInspector.cs
@@ -1,19 +1,50 @@
 ﻿using System;
-using System.Threading.Tasks;
+using Glimpse.Agent.Web.Framework;
+using Glimpse.Agent.Web.Message;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Features;
 
 namespace Glimpse.Agent.Web.Inspectors
 {
-    public class UserInspector : IInspector
+    public class UserInspector : Inspector
     {
-        public Task Before(HttpContext context)
+        private readonly IAgentBroker _broker;
+        private const string GlimpseCookie = ".Glimpse.Session";
+
+        public UserInspector(IAgentBroker broker)
         {
-            throw new NotImplementedException();
+            _broker = broker;
         }
 
-        public Task After(HttpContext context)
+        public override void After(HttpContext context)
         {
-            throw new NotImplementedException();
+            var user = context.User;
+            var userId = user.FindFirst("sub")?.Value ?? user.FindFirst("NameIdentifier")?.Value ?? context.Request.Cookies[GlimpseCookie];
+
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+#warning TODO: Use Glimpse RequestId
+                userId = Guid.NewGuid().ToString(); // TODO: This should be the Glimpse request ID
+
+                var response = context.Features.Get<IHttpResponseFeature>();
+                if (!response.HasStarted)
+                {
+                    context.Response.Cookies.Append(GlimpseCookie, userId);
+                }
+            }
+
+            var username = user.FindFirst("name")?.Value ?? userId.Crc16().ToUpper();
+            var email = user.FindFirst("email")?.Value;
+            var pic = user.FindFirst("picture")?.Value ?? GenerateGravatarUrl(email ?? userId);
+
+            _broker.SendMessage(new UserIdentification(userId, username, email, pic));
+        }
+
+        private string GenerateGravatarUrl(string email)
+        {
+            var preppedEmail = email.Trim().ToLower();
+            var hash = preppedEmail.Md5();
+            return $"http://www.gravatar.com/avatar/{hash}.jpg?d=identicon";
         }
     }
 }

--- a/src/Glimpse.Agent.Web/Message/UserIdentification.cs
+++ b/src/Glimpse.Agent.Web/Message/UserIdentification.cs
@@ -1,0 +1,23 @@
+namespace Glimpse.Agent.Web.Message
+{
+    public class UserIdentification
+    {
+        public UserIdentification(string userId, string username, string email, string image)
+        {
+            UserId = userId;
+            Username = username;
+            Email = email;
+            Image = image;
+        }
+
+#warning TODO: Need to promote UserIdentification.UserId
+        // TODO: [PromoteTo("request-userId")]
+        public string UserId { get; }
+
+        public string Username { get; }
+
+        public string Email { get; }
+
+        public string Image { get; }
+    }
+}

--- a/src/Glimpse.Agent.Web/Message/UserIdentification.cs
+++ b/src/Glimpse.Agent.Web/Message/UserIdentification.cs
@@ -10,8 +10,7 @@ namespace Glimpse.Agent.Web.Message
             Image = image;
         }
 
-#warning TODO: Need to promote UserIdentification.UserId
-        // TODO: [PromoteTo("request-userId")]
+        [PromoteTo("request-userId")]
         public string UserId { get; }
 
         public string Username { get; }

--- a/src/Glimpse.Common/Common/Crc16Extensions.cs
+++ b/src/Glimpse.Common/Common/Crc16Extensions.cs
@@ -1,0 +1,50 @@
+﻿using System.Text;
+
+namespace Glimpse
+{
+    // Crc16 implementaion from Marc Gravell at http://stackoverflow.com/a/22861111/107289
+    public static class Crc16Extensions
+    {
+        const ushort Polynomial = 0xA001;
+        static readonly ushort[] Table = new ushort[256];
+
+        public static string Crc16(this string utf8Input)
+        {
+            var bytes = Encoding.UTF8.GetBytes(utf8Input);
+            return ComputeChecksum(bytes).ToString("x2");
+        }
+
+        public static ushort ComputeChecksum(byte[] bytes)
+        {
+            ushort crc = 0;
+            for (var i = 0; i < bytes.Length; ++i)
+            {
+                byte index = (byte)(crc ^ i);
+                crc = (ushort)((crc >> 8) ^ Table[index]);
+            }
+            return crc;
+        }
+
+        static Crc16Extensions()
+        {
+            for (ushort i = 0; i < Table.Length; ++i)
+            {
+                ushort value = 0;
+                var temp = i;
+                for (byte j = 0; j < 8; ++j)
+                {
+                    if (((value ^ temp) & 0x0001) != 0)
+                    {
+                        value = (ushort)((value >> 1) ^ Polynomial);
+                    }
+                    else
+                    {
+                        value >>= 1;
+                    }
+                    temp >>= 1;
+                }
+                Table[i] = value;
+            }
+        }
+    }
+}

--- a/src/Glimpse.Common/Common/Md5Extensions.cs
+++ b/src/Glimpse.Common/Common/Md5Extensions.cs
@@ -1,0 +1,23 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Glimpse
+{
+    public static class Md5Extensions
+    {
+        private static readonly MD5 _md5 = MD5.Create();
+
+        public static string Md5(this string utf8Input)
+        {
+            var bytes = Encoding.UTF8.GetBytes(utf8Input);
+            var hash = _md5.ComputeHash(bytes);
+
+            StringBuilder sb = new StringBuilder();
+            foreach (var b in hash)
+            {
+                sb.Append(b.ToString("X2"));
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Glimpse.Common/project.json
+++ b/src/Glimpse.Common/project.json
@@ -14,10 +14,11 @@
         },
         "dnxcore50": {
             "dependencies": {
-                "System.Runtime": "4.0.21-beta-*", 
-                "System.ObjectModel": "4.0.10", 
+                "System.Runtime": "4.0.21-beta-*",
+                "System.ObjectModel": "4.0.10",
                 "System.Threading": "4.0.11-beta-*",
-                "System.Text.RegularExpressions": "4.0.11-beta-*"
+                "System.Text.RegularExpressions": "4.0.11-beta-*",
+                "System.Security.Cryptography.Algorithms": "4.0.0-beta-*"
             }
         }
     }

--- a/src/Glimpse.Server.Web/Resources/MessageHistoryResource.cs
+++ b/src/Glimpse.Server.Web/Resources/MessageHistoryResource.cs
@@ -30,6 +30,7 @@ namespace Glimpse.Server.Web
                     ResourceParameter.Custom("smax"),
                     ResourceParameter.Custom("tags"),
                     ResourceParameter.Custom("before"),
+                    ResourceParameter.Custom("user"),
                     ResourceParameter.Custom("types"));
             else
                 Parameters = new ResourceParameters(ResourceParameter.Custom("types"));
@@ -70,6 +71,9 @@ namespace Glimpse.Server.Web
 
                 if (parameters.ContainsKey("tags"))
                     filters.TagList = parameters["tags"].Split(',');
+
+                if (parameters.ContainsKey("user"))
+                    filters.UserId = parameters["user"];
 
                 if (parameters.ContainsKey("before"))
                     filters.RequesTimeBefore = DateTime.Parse(parameters["before"]);

--- a/src/Glimpse.Server.Web/Storage/IQueryRequests.cs
+++ b/src/Glimpse.Server.Web/Storage/IQueryRequests.cs
@@ -44,5 +44,7 @@ namespace Glimpse.Server.Web
         }
 
         public DateTime? RequesTimeBefore { get; set; }
+
+        public string UserId { get; set; }
     }
 }

--- a/src/Glimpse.Server.Web/Storage/InMemoryStorage.cs
+++ b/src/Glimpse.Server.Web/Storage/InMemoryStorage.cs
@@ -107,6 +107,9 @@ namespace Glimpse.Server.Web
                 if (filters.RequesTimeBefore.HasValue)
                     query = query.Where(i => i.DateTime.HasValue && i.DateTime < filters.RequesTimeBefore);
 
+                if (!string.IsNullOrWhiteSpace(filters.UserId))
+                    query = query.Where(i => !string.IsNullOrWhiteSpace(i.UserId) && i.UserId.Equals(filters.UserId, StringComparison.OrdinalIgnoreCase));
+
                 return query
                     .OrderByDescending(i => i.DateTime)
                     .Take(RequestsPerPage)

--- a/src/Glimpse.Server.Web/Storage/RequestIndices.cs
+++ b/src/Glimpse.Server.Web/Storage/RequestIndices.cs
@@ -28,6 +28,8 @@ namespace Glimpse.Server.Web
 
         public DateTime? DateTime { get; private set; }
 
+        public string UserId { get; set; }
+
         public IEnumerable<string> Tags => _tags.Distinct();
 
         public void Update(IMessage message)
@@ -50,6 +52,9 @@ namespace Glimpse.Server.Web
 
             var method = indices.GetValueOrDefault("request-method") as string;
             if (!string.IsNullOrWhiteSpace(method)) Method = method;
+
+            var userId = indices.GetValueOrDefault("request-userId") as string;
+            if (!string.IsNullOrWhiteSpace(userId)) UserId = userId;
 
             var statusCode = indices.GetValueOrDefault("request-statuscode") as int?;
             if (statusCode != null) StatusCode = statusCode;


### PR DESCRIPTION
Provide a mechanism for users to enhance the Glimpse experience by annotating user sessions with some sort of meaningful identifier. (Name? Username? Email?)

@leastprivilege has [a nice write up about security in ASP.NET 5](http://leastprivilege.com/2015/07/21/the-state-of-security-in-asp-net-5-and-mvc-6-claims-authentication/). His article leads me to believe that we might be able to leverage claims.

If this system worked automatically with other popular authentication frameworks, than that's even better.

We might want to consult with @leastprivilege & @brockallen about this, cause I'd love to make sure "it just works" with @IdentityServer
