### PR TITLE
Add common extension methods off HttpContext for Resources

### DIFF
--- a/src/Glimpse.Common/Internal/Extensions/JsonSerializerExtensions.cs
+++ b/src/Glimpse.Common/Internal/Extensions/JsonSerializerExtensions.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using GuidConverter = Glimpse.Common.Internal.Serialization.GuidConverter;
 
 namespace Glimpse.Internal.Extensions
 {
@@ -21,6 +23,14 @@ namespace Glimpse.Internal.Extensions
 
                 return stringWriter.ToString();
             }
+        }
+
+        public static void Configure(this JsonSerializer jsonSerializer)
+        {
+            jsonSerializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+            jsonSerializer.Converters.Add(new TimeSpanConverter());
+            jsonSerializer.Converters.Add(new StringValuesConverter());
+            jsonSerializer.Converters.Add(new GuidConverter());
         }
     }
 }

--- a/src/Glimpse.Common/Internal/Serialization/DefaultJsonSerializerProvider.cs
+++ b/src/Glimpse.Common/Internal/Serialization/DefaultJsonSerializerProvider.cs
@@ -1,6 +1,5 @@
-using Glimpse.Internal;
+using Glimpse.Internal.Extensions;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Glimpse.Common.Internal.Serialization
 {
@@ -9,10 +8,7 @@ namespace Glimpse.Common.Internal.Serialization
         private readonly JsonSerializer _jsonSerializer;
         public DefaultJsonSerializerProvider(JsonSerializer jsonSerializer)
         {
-            jsonSerializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
-            jsonSerializer.Converters.Add(new TimeSpanConverter());
-            jsonSerializer.Converters.Add(new StringValuesConverter());
-            jsonSerializer.Converters.Add(new GuidConverter());
+            jsonSerializer.Configure();
             _jsonSerializer = jsonSerializer;
         }
 

--- a/src/Glimpse.Server/Internal/Resources/ContextResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/ContextResource.cs
@@ -20,13 +20,11 @@ namespace Glimpse.Server.Internal.Resources
         {
             resourceBuilder.Run("context", "?contextId={contextId}{&types}", ResourceType.Client, async (context, parameters) =>
             {
-                var response = context.Response;
                 var contextId = parameters.ParseGuid("contextId");
 
                 if (!contextId.HasValue)
                 {
-                    response.StatusCode = 404;
-                    await response.WriteAsync("Required parameter 'contextId' is missing.");
+                    await context.RespondWith(new MissingParameterProblem("contextId").EnableCaching());
                     return;
                 }
 

--- a/src/Glimpse.Server/Internal/Resources/ContextResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/ContextResource.cs
@@ -34,8 +34,9 @@ namespace Glimpse.Server.Internal.Resources
 
                var list = await _storage.RetrieveByContextId(contextId.Value, types);
 
-                response.Headers[HeaderNames.ContentType] = "application/json";
-                await response.WriteAsync(list.ToJsonArray());
+                await context.RespondWith(
+                    new RawJson(list.ToJsonArray())
+                    .EnableCaching());
             });
         }
 

--- a/src/Glimpse.Server/Internal/Resources/EmbeddedFileResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/EmbeddedFileResource.cs
@@ -7,7 +7,6 @@ using Glimpse.Server.Resources;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.FileProviders;
 using Microsoft.AspNet.StaticFiles;
-using Microsoft.Net.Http.Headers;
 
 namespace Glimpse.Server.Internal.Resources
 {
@@ -15,9 +14,11 @@ namespace Glimpse.Server.Internal.Resources
     {
         public void Configure(IResourceBuilder resourceBuilder)
         {
-            UseCaching(resourceBuilder);
+            var appBuilder = resourceBuilder.AppBuilder;
 
-            resourceBuilder.AppBuilder.UseFileServer(new FileServerOptions
+            appBuilder.ModifyResponseWith(response => response.EnableCaching());
+
+            appBuilder.UseFileServer(new FileServerOptions
             {
                 RequestPath = "",
                 EnableDefaultFiles = true,
@@ -29,27 +30,6 @@ namespace Glimpse.Server.Internal.Resources
             {
                 resourceBuilder.RegisterResource(registration.Key, registration.Value);
             }
-        }
-
-        private static void UseCaching(IResourceBuilder resourceBuilder)
-        {
-#if !DEBUG
-            var cacheControl = new CacheControlHeaderValue
-            {
-                Public = true,
-                MaxAge = TimeSpan.FromDays(150)
-            };
-#else
-            var cacheControl = new CacheControlHeaderValue
-            {
-                NoCache = true,
-            };
-#endif
-            resourceBuilder.AppBuilder.Use(async (ctx, next) =>
-            {
-                ctx.Response.Headers[HeaderNames.CacheControl] = cacheControl.ToString();
-                await next();
-            });
         }
 
         public abstract ResourceType Type { get; }

--- a/src/Glimpse.Server/Internal/Resources/MessageHistoryResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/MessageHistoryResource.cs
@@ -20,8 +20,6 @@ namespace Glimpse.Server.Internal.Resources
 
         public async Task Invoke(HttpContext context, IDictionary<string, string> parameters)
         {
-            var response = context.Response;
-
             var types = parameters.ParseEnumerable("types").ToArray();
 
             if (types.Length == 0)

--- a/src/Glimpse.Server/Internal/Resources/MessageHistoryResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/MessageHistoryResource.cs
@@ -26,15 +26,15 @@ namespace Glimpse.Server.Internal.Resources
 
             if (types.Length == 0)
             {
-                response.StatusCode = 404;
-                await response.WriteAsync("Required parameter 'types' is missing.");
+                await context.RespondWith(
+                    new MissingParameterProblem("types")
+                    .EnableCaching());
                 return;
             }
 
             var list = await _store.RetrieveByType(types);
 
-            response.Headers[HeaderNames.ContentType] = "application/json";
-            await response.WriteAsync(list.ToJsonArray());
+            await context.RespondWith(new RawJson(list.ToJsonArray()));
         }
 
         public string Name => "message-history";

--- a/src/Glimpse.Server/Internal/Resources/MessageIngressResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/MessageIngressResource.cs
@@ -22,7 +22,6 @@ namespace Glimpse.Server.Internal.Resources
 
         public async Task Invoke(HttpContext context, IDictionary<string, string> parameters)
         {
-            var response = context.Response;
             if (context.Request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase))
             {
                 // TODO: Wrap in a try block and return Http Problem when required
@@ -32,16 +31,14 @@ namespace Glimpse.Server.Internal.Resources
                     _messageServerBus.SendMessage(message);
                 }
 
-                response.StatusCode = (int)HttpStatusCode.Accepted;
-                response.Headers[HeaderNames.ContentType] = "text/plain";
-                await response.WriteAsync($"Accepted: " + string.Join(", ", messages.Select(m => m.Id.ToString("N"))));
+                await context.RespondWith(
+                    new HttpStatusResponse(HttpStatusCode.Accepted, 
+                    "Accepted: " + string.Join(", ", messages.Select(m => m.Id.ToString("N")))));
             }
             else
             {
-                response.StatusCode = (int) HttpStatusCode.MethodNotAllowed;
-                response.Headers[HeaderNames.Allow] = "POST";
-                response.Headers[HeaderNames.ContentType] = "text/plain";
-                await response.WriteAsync("Please POST to this resource.");
+                await context.RespondWith(
+                    new InvalidMethodProblem(context.Request.Method, "POST"));
             }
         }
 

--- a/src/Glimpse.Server/Internal/Resources/MessageStreamResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/MessageStreamResource.cs
@@ -51,6 +51,8 @@ namespace Glimpse.Server.Internal.Resources
                 var contextId = parameters.ParseGuid("contextId");
                 var filter = GetStreamFilter(types, contextId);
 
+                //var sse = await context.RespondWith(new ServerSentEvent());
+
                 context.Response.ContentType = "text/event-stream";
                 await context.Response.WriteAsync("retry: 5000\n\n");
                 await context.Response.Body.FlushAsync();

--- a/src/Glimpse.Server/Internal/Resources/MessageStreamResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/MessageStreamResource.cs
@@ -51,11 +51,8 @@ namespace Glimpse.Server.Internal.Resources
                 var contextId = parameters.ParseGuid("contextId");
                 var filter = GetStreamFilter(types, contextId);
 
-                //var sse = await context.RespondWith(new ServerSentEvent());
-
-                context.Response.ContentType = "text/event-stream";
-                await context.Response.WriteAsync("retry: 5000\n\n");
-                await context.Response.Body.FlushAsync();
+                var sse = await context.RespondWith(new ServerSentEventResponse());
+                await sse.SetRetry(TimeSpan.FromSeconds(5));
 
                 var unSubscribe = _senderSubject.Where(filter).Subscribe(async t =>
                 {
@@ -63,9 +60,7 @@ namespace Glimpse.Server.Internal.Resources
 
                     try
                     {
-                        await context.Response.WriteAsync($"event: {t.Event}\n");
-                        await context.Response.WriteAsync($"data: [{t.Data}]\n\n");
-                        await context.Response.Body.FlushAsync();
+                        await sse.SendData(data: $"[{t.Data}]", @event: t.Event);
                     }
                     finally 
                     {

--- a/src/Glimpse.Server/Internal/Resources/MetadataResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/MetadataResource.cs
@@ -1,34 +1,26 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Glimpse.Common.Internal.Serialization;
 using Glimpse.Server.Configuration;
 using Glimpse.Server.Resources;
 using Microsoft.AspNet.Http;
-using Microsoft.Net.Http.Headers;
-using Newtonsoft.Json;
-using Glimpse.Internal.Extensions;
 
 namespace Glimpse.Server.Internal.Resources
 {
     public class MetadataResource : IResource
     {
         private readonly IMetadataProvider _metadataProvider;
-        private readonly JsonSerializer _jsonSerializer;
         private Metadata _metadata;
 
-        public MetadataResource(IMetadataProvider metadataProvider, IJsonSerializerProvider serializerProvider)
+        public MetadataResource(IMetadataProvider metadataProvider)
         {
             _metadataProvider = metadataProvider;
-            _jsonSerializer = serializerProvider.GetJsonSerializer();
         }
 
         public async Task Invoke(HttpContext context, IDictionary<string, string> parameters)
         {
             var metadata = GetMetadata();
 
-            var response = context.Response;
-            response.Headers[HeaderNames.ContentType] = "application/json";
-            await response.WriteAsync(_jsonSerializer.Serialize(metadata));
+            await context.RespondWith(new Json(metadata));
         }
 
         private Metadata GetMetadata()

--- a/src/Glimpse.Server/Internal/Resources/NullResponse.cs
+++ b/src/Glimpse.Server/Internal/Resources/NullResponse.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Glimpse.Server.Resources;
+using Microsoft.AspNet.Http;
+
+namespace Glimpse.Server.Internal.Resources
+{
+    public class NullResponse : IResponse
+    {
+        public async Task Respond(HttpContext context)
+        {
+            // TODO: Use Task.CompletedTask when it's available.
+            // See https://github.com/aspnet/Home/issues/337 for more details
+            await Task.FromResult(false);
+        }
+    }
+}

--- a/src/Glimpse.Server/Internal/Resources/RequestHistoryResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/RequestHistoryResource.cs
@@ -6,7 +6,6 @@ using Glimpse.Server.Internal.Extensions;
 using Glimpse.Server.Resources;
 using Glimpse.Server.Storage;
 using Microsoft.AspNet.Http;
-using Microsoft.Net.Http.Headers;
 
 namespace Glimpse.Server.Internal.Resources
 {
@@ -24,7 +23,6 @@ namespace Glimpse.Server.Internal.Resources
 
         public async Task Invoke(HttpContext context, IDictionary<string, string> parameters)
         {
-            var response = context.Response;
             var filters = GetFilters(parameters);
 
             IEnumerable<string> list;
@@ -38,8 +36,8 @@ namespace Glimpse.Server.Internal.Resources
                 list = await _requests.Query(filters);
             }
 
-            response.Headers[HeaderNames.ContentType] = "application/json";
-            await response.WriteAsync(list.ToJsonArray());
+            await context.RespondWith(
+                new RawJson(list.ToJsonArray()));
         }
 
         public string Name => "request-history";

--- a/src/Glimpse.Server/Internal/Resources/ResponseDecorator.cs
+++ b/src/Glimpse.Server/Internal/Resources/ResponseDecorator.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Glimpse.Server.Resources;
+using Microsoft.AspNet.Http;
+
+namespace Glimpse.Server.Internal.Resources
+{
+    public class ResponseDecorator : IResponse
+    {
+        private readonly IResponse _response;
+        private readonly Action<HttpContext> _decoration;
+        public ResponseDecorator(IResponse response, Action<HttpContext> decoration)
+        {
+            _response = response;
+            _decoration = decoration;
+        }
+
+        public async Task Respond(HttpContext context)
+        {
+            _decoration(context);
+            await _response.Respond(context);
+        }
+    }
+}

--- a/src/Glimpse.Server/Internal/Resources/ScriptOptionsResource.cs
+++ b/src/Glimpse.Server/Internal/Resources/ScriptOptionsResource.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Glimpse.Initialization;
 using Glimpse.Server.Resources;
 using Microsoft.AspNet.Http;
-using Microsoft.Net.Http.Headers;
 
 namespace Glimpse.Server.Internal.Resources
 {
@@ -30,10 +29,9 @@ namespace Glimpse.Server.Internal.Resources
     }}
 }}";
 
-            var response = context.Response;
-            response.Headers[HeaderNames.ContentType] = "application/json";
-            response.Headers[HeaderNames.ContentDisposition] = "attachment; filename = glimpse.json";
-            await response.WriteAsync(json);
+            await context.RespondWith(
+                new RawJson(json)
+                .AsFile("glimpse.json"));
         }
 
         public string Name => "script-options";

--- a/src/Glimpse.Server/Resources/HttpContextExtensions.cs
+++ b/src/Glimpse.Server/Resources/HttpContextExtensions.cs
@@ -1,0 +1,77 @@
+﻿// ReSharper disable RedundantUsingDirective
+using System;
+// ReSharper restore RedundantUsingDirective
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Glimpse.Server.Resources
+{
+    public static class HttpContextExtensions
+    {
+        public async static Task RespondWith(this HttpContext context, IResponse response)
+        {
+            await response.Respond(context);
+        }
+
+        public static IResponse EnableCaching(this IResponse response, TimeSpan? timeSpan = null)
+        {
+            return new ResponseDecorator(response, ctx =>
+            {
+#if !DEBUG
+                var cacheControl = new CacheControlHeaderValue
+                {
+                    Public = true,
+                    MaxAge = timeSpan ?? TimeSpan.FromDays(150)
+                };
+#else
+                var cacheControl = new CacheControlHeaderValue
+                {
+                    NoCache = true,
+                };
+#endif
+                ctx.Response.Headers[HeaderNames.CacheControl] = cacheControl.ToString();
+            });
+        }
+    }
+
+    public interface IResponse
+    {
+        Task Respond(HttpContext context);
+    }
+
+    public class RawJson : IResponse
+    {
+        private readonly string _json;
+
+        public RawJson(string json)
+        {
+            _json = json;
+        }
+
+        public async Task Respond(HttpContext context)
+        {
+            var response = context.Response;
+            response.Headers[HeaderNames.ContentType] = "application/json";
+            await response.WriteAsync(_json);
+        }
+    }
+
+    public class ResponseDecorator : IResponse
+    {
+        private readonly IResponse _response;
+        private readonly Action<HttpContext> _decoration;
+        public ResponseDecorator(IResponse response, Action<HttpContext> decoration)
+        {
+            _response = response;
+            _decoration = decoration;
+        }
+
+        public async Task Respond(HttpContext context)
+        {
+            _decoration(context);
+            await _response.Respond(context);
+        }
+    }
+}

--- a/src/Glimpse.Server/Resources/HttpStatusResponse.cs
+++ b/src/Glimpse.Server/Resources/HttpStatusResponse.cs
@@ -1,0 +1,42 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Glimpse.Server.Resources
+{
+    public class HttpStatusResponse : IResponse
+    {
+        private readonly int _statusCode;
+        private readonly string _message;
+
+        public HttpStatusResponse(HttpStatusCode statusCode) : this((int)statusCode, null)
+        {
+        }
+
+        public HttpStatusResponse(HttpStatusCode statusCode, string message) : this((int)statusCode, message)
+        {
+        }
+
+        public HttpStatusResponse(int statusCode) : this(statusCode, null)
+        {
+        }
+
+        public HttpStatusResponse(int statusCode, string message)
+        {
+            _statusCode = statusCode;
+            _message = message;
+        }
+
+        public async Task Respond(HttpContext context)
+        {
+            var response = context.Response;
+            response.StatusCode = _statusCode;
+            if (!string.IsNullOrWhiteSpace(_message))
+            {
+                response.Headers[HeaderNames.ContentType] = "text/plain";
+                await response.WriteAsync(_message);
+            }
+        }
+    }
+}

--- a/src/Glimpse.Server/Resources/IResponse.cs
+++ b/src/Glimpse.Server/Resources/IResponse.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+
+namespace Glimpse.Server.Resources
+{
+    public interface IResponse
+    {
+        Task Respond(HttpContext context);
+    }
+}

--- a/src/Glimpse.Server/Resources/InvalidMethodProblem.cs
+++ b/src/Glimpse.Server/Resources/InvalidMethodProblem.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Glimpse.Server.Resources
+{
+    public class InvalidMethodProblem : Problem
+    {
+        private readonly IEnumerable<string> _allowedMethods;
+        private readonly string _attemptedMethod;
+        public InvalidMethodProblem(string attemptedMethod, params string[] allowedMethods)
+        {
+            if (allowedMethods.Length == 0)
+                throw new ArgumentException("At least one method must be allowed.", nameof(allowedMethods));
+
+            _allowedMethods = allowedMethods.Select(m => m.ToUpper());
+            _attemptedMethod = attemptedMethod;
+
+            Extensions["AllowedMethods"] = _allowedMethods;
+        }
+
+        public override Task Respond(HttpContext context)
+        {
+            context.Response.Headers[HeaderNames.Allow] = string.Join(", ", _allowedMethods);
+            return base.Respond(context);
+        }
+
+        public override Uri Type => new Uri("http://getglimpse.com/Docs/Troubleshooting/InvalidMethod");
+        public override string Title => "Method Not Allowed";
+        public override string Details => $"The method '{_attemptedMethod}' is not allowed on this resource.";
+        public override int StatusCode => (int) HttpStatusCode.MethodNotAllowed;
+    }
+}

--- a/src/Glimpse.Server/Resources/Json.cs
+++ b/src/Glimpse.Server/Resources/Json.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Glimpse.Internal.Extensions;
+using Microsoft.AspNet.Http;
+using Newtonsoft.Json;
+
+namespace Glimpse.Server.Resources
+{
+    public class Json : IResponse
+    {
+        private readonly object _obj;
+        private readonly string _contentType;
+        public Json(object obj) : this(obj, "application/json")
+        {
+        }
+
+        public Json(object obj, string contentType)
+        {
+            _obj = obj;
+            _contentType = contentType;
+        }
+
+        public async Task Respond(HttpContext context)
+        {
+            var jsonSerializer = new JsonSerializer();
+            jsonSerializer.Configure();
+
+            var json = jsonSerializer.Serialize(_obj);
+
+            var response = new RawJson(json, _contentType);
+            await response.Respond(context);
+        }
+    }
+}

--- a/src/Glimpse.Server/Resources/MissingParameterProblem.cs
+++ b/src/Glimpse.Server/Resources/MissingParameterProblem.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net;
+
+namespace Glimpse.Server.Resources
+{
+    public class MissingParameterProblem : Problem
+    {
+        private readonly string _parameterName;
+        public MissingParameterProblem(string parameterName)
+        {
+            _parameterName = parameterName;
+        }
+
+        public override Uri Type => new Uri("http://getglimpse.com/Docs/Troubleshooting/MissingParameter");
+
+        public override string Title => "Missing Required Parameter";
+
+        public override string Details => $"Required parameter '{_parameterName}' is missing.";
+
+        public override int StatusCode => (int) HttpStatusCode.NotFound;
+    }
+}

--- a/src/Glimpse.Server/Resources/Problem.cs
+++ b/src/Glimpse.Server/Resources/Problem.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+
+namespace Glimpse.Server.Resources
+{
+    public abstract class Problem : IResponse
+    {
+        protected Problem()
+        {
+            Extensions = new Dictionary<string, object>();
+        }
+
+        public IDictionary<string, object> Extensions { get; }
+
+        public abstract Uri Type { get; }
+
+        public abstract string Title { get; }
+
+        public abstract string Details { get; }
+
+        public abstract int StatusCode { get; }
+
+        public virtual async Task Respond(HttpContext context)
+        {
+            context.Response.StatusCode = StatusCode;
+
+            Extensions["Status"] = StatusCode;
+            Extensions["Type"] = Type.AbsoluteUri;
+            Extensions["Title"] = Title;
+            Extensions["Details"] = Details;
+
+            var response = new Json(Extensions, "application/problem+json");
+            await response.Respond(context);
+        }
+    }
+}

--- a/src/Glimpse.Server/Resources/RawJson.cs
+++ b/src/Glimpse.Server/Resources/RawJson.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+
+namespace Glimpse.Server.Resources
+{
+    public class RawJson : IResponse
+    {
+        private readonly string _json;
+        private readonly string _contentType;
+
+        public RawJson(string json) : this(json, "application/json")
+        {
+        }
+
+        public RawJson(string json, string contentType)
+        {
+            _json = json;
+            _contentType = contentType;
+        }
+
+        public async Task Respond(HttpContext context)
+        {
+            var response = context.Response;
+            response.ContentType = _contentType;
+            await response.WriteAsync(_json);
+        }
+    }
+}


### PR DESCRIPTION
Extension methods hanging off of context will be provided to perform common tasks such as `.ConfigureCors()`, `.ConfigureCaching()` or `.AddETag()`. 
