### PR TITLE
Fix invalid JSON caused by localized decimal mark

### DIFF
--- a/src/Glimpse.Common/Internal/Serialization/TimeSpanConverter.cs
+++ b/src/Glimpse.Common/Internal/Serialization/TimeSpanConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Glimpse.Internal
@@ -15,7 +16,7 @@ namespace Glimpse.Internal
                 result = Math.Round(convertedNullable.Value.TotalMilliseconds, 2);
             }
             
-            writer.WriteRawValue(result.ToString());
+            writer.WriteRawValue(result.ToString(CultureInfo.InvariantCulture));
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
As mentioned in #123 TimeSpanConverter produced wrongly formatted (non JSON) floating point numbers on systems with comma (or any other decimal mark) instead of dot causing the Glimpse HUD not showing at all as $.getJson doesn't return without error.

The produced JSON on a system with comma as seperator before this PR looked like this:

``` json
...
{
    "id": "0233a1ec5c7c3f22a1e52540157799a2",
    "ordinal": 524,
    "types": ["after-action-invoked"],
    "payload": {
        "actionId": "2d93d149-adba-4fca-a038-4162a6b96558",
        "actionName": "Index",
        "actionControllerName": "Home",
        "actionInvokedEndTime": "2016-07-27T14:47:11.8773171Z",
        "actionInvokedDuration": 27,64,
        "actionInvokedOffset": 0,76
    },
    "context": {
        "id": "dcc911aba2e540788469117426011cb1",
        "type": "Request"
    }
}
...
```

After this PR the json will look like this:

``` json
...
{
    "id": "0233a1ec5c7c3f22a1e52540157799a2",
    "ordinal": 524,
    "types": ["after-action-invoked"],
    "payload": {
        "actionId": "2d93d149-adba-4fca-a038-4162a6b96558",
        "actionName": "Index",
        "actionControllerName": "Home",
        "actionInvokedEndTime": "2016-07-27T14:47:11.8773171Z",
        "actionInvokedDuration": 27.64,
        "actionInvokedOffset": 0.76
    },
    "context": {
        "id": "dcc911aba2e540788469117426011cb1",
        "type": "Request"
    }
}
...
```
