### PR TITLE
Use Environment.MachineName

### DIFF
--- a/src/Glimpse.Agent.AspNet/Internal/Inspectors/AspNet/EnvironmentInspector.cs
+++ b/src/Glimpse.Agent.AspNet/Internal/Inspectors/AspNet/EnvironmentInspector.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Runtime.InteropServices;
 using Glimpse.Agent.AspNet.Messages;
 using Glimpse.Agent.Inspectors;
 using Microsoft.AspNetCore.Http;
-using System.Runtime.InteropServices;
 
 namespace Glimpse.Agent.AspNet.Internal.Inspectors.AspNet
 {
@@ -26,7 +26,7 @@ namespace Glimpse.Agent.AspNet.Internal.Inspectors.AspNet
 
                 _message = new EnvironmentMessage
                 {
-                    ServerName = Environment.GetEnvironmentVariable("COMPUTERNAME"), // TODO: make sure its cross plat
+                    ServerName = Environment.MachineName,
                     ServerTime = time.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff"),
                     ServerTimezoneOffset = time.ToString("zzz"),
                     ServerDaylightSavingTime = isDaylightSavingTime,


### PR DESCRIPTION
Instead of using Environment.GetEnvironmentVariable("COMPUTERNAME") - as this is hacky... use Environment.MachineName.

Implemented here: https://github.com/dotnet/corefx/pull/5428

Also reordered usings.